### PR TITLE
feat: connect API in UserTweetPage, change name from 'users' into 'tw…

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -69,38 +69,3 @@ export const getUserData = async ({ token, userId }) => {
     return { error }
   }
 }
-
-// Jasmine 新增: 拿到使用者首頁推文的API
-export const getMainPageUserTweets = async ({ token, userId }) => {
-  try {
-    const { data } = await axios.get(`${authURL}/tweets`, {
-      headers: {
-        Authorization: 'Bearer ' + token,
-      },
-    })
-    return data
-  } catch (error) {
-    console.error('[GetUserData Failed]:', error)
-    return { error }
-  }
-}
-// 雪央 新增: 拿到使用者的所有推文(未完成)
-export const getUserTweets = async ({ token, userId }) => {
-  try {
-    const { data } = await axios.get(`${authURL}/users/${userId}/tweets`, {
-      headers: {
-        Authorization: 'Bearer ' + token,
-      },
-    })
-        if (data) {
-      return { success: true, ...data }
-    }
-    return data
-  } catch (error) {
-    console.error('[GetUserTweets Failed]:', error)
-    return { error }
-  }
-}
-
-
-

--- a/src/api/mainPageTweets.js
+++ b/src/api/mainPageTweets.js
@@ -1,0 +1,20 @@
+// Jasmine
+
+import axios from 'axios'
+
+const authURL = 'https://enigmatic-refuge-29514.herokuapp.com/api'
+
+// Jasmine 新增: 拿到使用者首頁推文的API
+export const getMainPageUserTweets = async ({ token, userId }) => {
+  try {
+    const { data } = await axios.get(`${authURL}/tweets`, {
+      headers: {
+        Authorization: 'Bearer ' + token,
+      },
+    })
+    return data
+  } catch (error) {
+    console.error('[GetUserData Failed]:', error)
+    return { error }
+  }
+}

--- a/src/api/userTweetPagePostTweets.js
+++ b/src/api/userTweetPagePostTweets.js
@@ -1,0 +1,20 @@
+// Jasmine
+
+import axios from 'axios'
+
+const authURL = 'https://enigmatic-refuge-29514.herokuapp.com/api'
+
+// 雪央 新增: 拿到使用者的所有推文(未完成)
+export const getUserPostTweets = async ({ token, userId }) => {
+  try {
+    const { data } = await axios.get(`${authURL}/users/${userId}/tweets`, {
+      headers: {
+        Authorization: 'Bearer ' + token,
+      },
+    })
+    return data
+  } catch (error) {
+    console.error('[GetUserTweets Failed]:', error)
+    return { error }
+  }
+}

--- a/src/components/TweetItem/TweetItem.jsx
+++ b/src/components/TweetItem/TweetItem.jsx
@@ -5,22 +5,34 @@ import { ReactComponent as DefaultAvatar } from 'assets/icons/default_avatar.svg
 import { ReactComponent as Reply } from 'assets/icons/reply.svg'
 import { ReactComponent as Like } from 'assets/icons/heart.svg'
 
-const TweetItem = ({ user }) => {
+const TweetItem = ({ tweet, page }) => {
   return (
     <div className={styles.TweetItemContainer}>
       <DefaultAvatar className={styles.DefaultAvatar} />
       <div className={styles.Tweet}>
-        <span className={styles.UserName}>{user.User.name}</span>
-        <span className={styles.UserAcount}>@{user.User.account}・</span>
-        <div className={styles.TweetContent}>{user.description}</div>
+        <span className={styles.UserName}>
+          {page === 'mainTweets' ? tweet.User.name : ''}
+        </span>
+        <span className={styles.UserAcount}>
+          @{page === 'mainTweets' ? tweet.User.account : ''}・
+        </span>
+        <div className={styles.TweetContent}>{tweet.description}</div>
         <div className={styles.Icon}>
           <div className={styles.Message}>
             <Reply className={styles.Reply} />
-            <span className={styles.Number}>{user.repliedCount}</span>
+            <span className={styles.Number}>
+              {page === 'mainTweets'
+                ? tweet.repliedCount
+                : tweet.Replies.totalReplies}
+            </span>
           </div>
           <div className={styles.Heart}>
             <Like className={styles.Like} />
-            <span className={styles.Number}>{user.likedCount}</span>
+            <span className={styles.Number}>
+              {page === 'mainTweets'
+                ? tweet.likedCount
+                : tweet.Likes.totalLikes}
+            </span>
           </div>
         </div>
       </div>

--- a/src/components/TweetItemCollection/TweetItemCollection.jsx
+++ b/src/components/TweetItemCollection/TweetItemCollection.jsx
@@ -2,11 +2,11 @@
 
 import TweetItem from 'components/TweetItem/TweetItem'
 
-const TweetItemCollection = ({ users }) => {
+const TweetItemCollection = ({ tweets, page }) => {
   return (
     <div>
-      {users.map((user) => {
-        return <TweetItem key={user.id} user={user} />
+      {tweets.map((tweet) => {
+        return <TweetItem key={tweet.id} tweet={tweet} page={page} />
       })}
     </div>
   )

--- a/src/components/TweetList/TweetList.jsx
+++ b/src/components/TweetList/TweetList.jsx
@@ -7,7 +7,7 @@ import TweetItemCollection from 'components/TweetItemCollection/TweetItemCollect
 import TweetModal from 'components/TweetModal/TweetModal'
 import { useState } from 'react'
 
-const TweetList = ({ users }) => {
+const TweetList = ({ tweets, page }) => {
   const [modalState, setModalState] = useState(false)
   return (
     <div className={styles.TweetListContainer}>
@@ -25,7 +25,7 @@ const TweetList = ({ users }) => {
         <TweetModal setModalState={setModalState} modalState={modalState} />
       )}
       {/* <TweetModal avatar={avatar} /> */}
-      <TweetItemCollection users={users} />
+      <TweetItemCollection tweets={tweets} page={page} />
     </div>
   )
 }

--- a/src/components/UserPostList/UserPostList.jsx
+++ b/src/components/UserPostList/UserPostList.jsx
@@ -10,7 +10,7 @@ import TweetItemCollection from 'components/TweetItemCollection/TweetItemCollect
 import ReplyItemCollection from 'components/ReplyItemCollection/ReplyItemCollection'
 import { useEffect, useState } from 'react'
 
-const UserPostList = () => {
+const UserPostList = ({tweets, page}) => {
   const navigate = useNavigate()
   const [userData, setUserData] = useState({
     account: '',
@@ -103,7 +103,7 @@ const UserPostList = () => {
         </div>
       </div>
       {/* 推文 */}
-      <TweetItemCollection />
+      <TweetItemCollection tweets={tweets} page={page}/>
       {/* 回覆 */}
       {/* <ReplyItemCollection /> */}
     </div>

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -7,36 +7,36 @@ import TweetList from 'components/TweetList/TweetList'
 import PopularUserList from 'components/PopularUserList/PopularUserList'
 
 import { useNavigate } from 'react-router-dom'
-import { getMainPageUserTweets } from 'api/auth'
+import { getMainPageUserTweets } from 'api/mainPageTweets'
 import { useEffect, useState } from 'react'
 
 const MainPage = () => {
   const navigate = useNavigate()
-  const [users, setUsers] = useState([])
+  const [tweets, setTweets] = useState([])
 
   useEffect(() => {
-    const getUsers = async () => {
+    const getTweets = async () => {
       try {
         const token = localStorage.getItem('token')
         const userId = localStorage.getItem('userId')
         if (!token) {
           navigate('/login')
         }
-        const users = await getMainPageUserTweets({ token, userId })
-        if (users) {
-          setUsers(users)
+        const tweets = await getMainPageUserTweets({ token, userId })
+        if (tweets) {
+          setTweets(tweets)
         }
       } catch (error) {
         console.error(error)
       }
     }
-    getUsers()
+    getTweets()
   }, [navigate])
 
   return (
     <div className={styles.MainPageContainer}>
       <Sidebar page="home" />
-      <TweetList users={users} />
+      <TweetList tweets={tweets} page="mainTweets" />
       <PopularUserList />
     </div>
   )

--- a/src/pages/UserTweetPage/UserTweetPage.jsx
+++ b/src/pages/UserTweetPage/UserTweetPage.jsx
@@ -6,76 +6,37 @@ import Sidebar from 'components/Sidebar/Sidebar'
 import UserPostList from 'components/UserPostList/UserPostList'
 import PopularUserList from 'components/PopularUserList/PopularUserList'
 
-// 帶入假資料
-const dummyUsers = [
-  {
-    id: 34,
-    description: 'Quo qui dolorem quasi nemo fugiat.',
-    UserId: 14,
-    createdAt: '2021-06-15T09:47:34.000Z',
-    updatedAt: '2023-02-05T06:59:58.000Z',
-    Likes: {
-      totalLikes: 1,
-      isLiked: 1,
-    },
-    Replies: {
-      totalReplies: 3,
-    },
-    isLiked: true,
-  },
-  {
-    id: 44,
-    description: 'Aliquid dolorem aut adipisci impedit omnis aperiam vel.',
-    UserId: 14,
-    createdAt: '2021-04-19T23:07:00.000Z',
-    updatedAt: '2023-02-14T05:40:43.000Z',
-    Likes: {
-      totalLikes: 1,
-      isLiked: 0,
-    },
-    Replies: {
-      totalReplies: 3,
-    },
-    isLiked: false,
-  },
-  {
-    id: 4,
-    description:
-      'Commodi voluptas magnam et veniam ut quas ea voluptatem omnis.',
-    UserId: 14,
-    createdAt: '2021-02-07T11:39:44.000Z',
-    updatedAt: '2023-02-13T14:40:22.000Z',
-    Likes: {
-      totalLikes: 0,
-      isLiked: 0,
-    },
-    Replies: {
-      totalReplies: 3,
-    },
-    isLiked: false,
-  },
-  {
-    id: 24,
-    description: 'In distinctio reprehenderit dolores sequi.',
-    UserId: 14,
-    createdAt: '2021-01-12T14:06:41.000Z',
-    updatedAt: '2023-02-05T05:50:32.000Z',
-    Likes: {
-      totalLikes: 1,
-      isLiked: 0,
-    },
-    Replies: {
-      totalReplies: 3,
-    },
-    isLiked: false,
-  },
-]
+import { useNavigate } from 'react-router-dom'
+import { getUserPostTweets } from 'api/userTweetPagePostTweets'
+import { useEffect, useState } from 'react'
 
 const UserTweetPage = () => {
+  const navigate = useNavigate()
+  const [tweets, setTweets] = useState([])
+
+  useEffect(() => {
+    const getTweets = async () => {
+      try {
+        const token = localStorage.getItem('token')
+        const userId = localStorage.getItem('userId')
+        if (!token) {
+          navigate('/login')
+        }
+        const tweets = await getUserPostTweets({ token, userId })
+        if (tweets) {
+          setTweets(tweets)
+        }
+      } catch (error) {
+        console.error(error)
+      }
+    }
+    getTweets()
+  }, [navigate])
+
   return (
     <div className={styles.UserTweetPageContainer}>
       <Sidebar page="user" />
-      <UserPostList users={dummyUsers} />
+      <UserPostList tweets={tweets} page="userPostTweets" />
       <PopularUserList />
     </div>
   )


### PR DESCRIPTION
…eets' and add props in MainPage, classify the api context.

串接  UserTweetPage (個人資料頁) 的推文，將 MainPage 中的 'users' 名稱改為 'tweets'。在 MainPage 加入 props ('page')，並且將 API 文件分類。